### PR TITLE
filters before video codec

### DIFF
--- a/ff_presets/preset_video.py
+++ b/ff_presets/preset_video.py
@@ -27,12 +27,12 @@ class PVideo(_Preset):
             self._src = read_yaml(self.path)
         else:
             self._src = copy.deepcopy(src)
+        self._cmd.append(self.size)
         self._cmd.append(self.codec)
         self._cmd.append(self.pix_fmt)
         self._cmd.append(self.crf)
         self._cmd.append(self.vframes)
         self._cmd.append(self.fps)
-        self._cmd.append(self.size)
         self._cmd.append(self.no_scenecut)
         self._cmd.append(self.bitrate)
         self._cmd.append(self.maxrate)


### PR DESCRIPTION
First we resize the frame, then we encode. That would not be an extra load.